### PR TITLE
chore: Remove validate_manifest hook from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,11 +29,6 @@ repos:
     args: [--fix, --exit-non-zero-on-fix, --show-fixes]
   - id: ruff-format
 
-- repo: https://github.com/pre-commit/pre-commit
-  rev: v4.5.1
-  hooks:
-  - id: validate_manifest
-
 - repo: https://github.com/python-jsonschema/check-jsonschema
   rev: 0.37.0
   hooks:


### PR DESCRIPTION
Removed the validate_manifest hook from pre-commit configuration.